### PR TITLE
Compatibility with Minecraft 1.16.220

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,10 +1,10 @@
 name: StairSeat
 api: 3.14.1
 main: korado531m7\StairSeat\StairSeat
-version: 1.5.8
+version: 1.5.9
 author: korado531m7
 description: Enable to sit on the stair block
-mcpe-protocol: 428
+mcpe-protocol: 431
 permissions:
   stairseat.toggle:
     description: "Toggle to sit"


### PR DESCRIPTION
Compatibility with PocketMine 3.19.0 for Minecraft 1.16.220 (Protocol 431)